### PR TITLE
fix: exclude node_modules from OCI artifact push

### DIFF
--- a/src/cli/commands/apply.ts
+++ b/src/cli/commands/apply.ts
@@ -527,7 +527,14 @@ export const apply_command = define_command({
                 const git_revision = await get_git_revision(project_root);
 
                 const kubeconfig_flag = temp_kubeconfig ? ` --kubeconfig=${temp_kubeconfig}` : '';
-                const push_cmd = `flux push artifact ${oci_url} --path="${project_root}" --source="${git_source}" --revision="${git_revision}"${kubeconfig_flag}`;
+                const ignore_paths = [
+                  'node_modules/',
+                  '.git/',
+                  '.gitignore',
+                  '.gitmodules',
+                  '.gitattributes',
+                ].join(',');
+                const push_cmd = `flux push artifact ${oci_url} --path="${project_root}" --source="${git_source}" --revision="${git_revision}" --ignore-paths "${ignore_paths}"${kubeconfig_flag}`;
                 await execAsync(push_cmd, { timeout: 120000 });
                 console.log(`    ✓ Pushed to ${oci_url}`);
               } catch (error) {


### PR DESCRIPTION
## Summary
- Adds `--ignore-paths` to `flux push artifact` command to exclude `node_modules/` and git metadata files
- Fixes "file name too long" error caused by deeply nested circular `node_modules` symlinks during OCI artifact push

Closes #147

## Test plan
- [x] All 787 tests pass
- [x] Build succeeds
- [ ] Deploy a new cluster with `node_modules` present in project root

🤖 Generated with [Claude Code](https://claude.com/claude-code)