### PR TITLE
fix(action): add bun global bin to PATH

### DIFF
--- a/action/kustodian-pr-diff/action.yml
+++ b/action/kustodian-pr-diff/action.yml
@@ -43,7 +43,9 @@ runs:
 
     - name: Install kustodian
       shell: bash
-      run: bun install -g kustodian@${{ inputs.kustodian-version }}
+      run: |
+        bun install -g kustodian@${{ inputs.kustodian-version }}
+        echo "$(bun pm bin -g)" >> "$GITHUB_PATH"
 
     - name: Install project dependencies
       shell: bash

--- a/action/kustodian/action.yml
+++ b/action/kustodian/action.yml
@@ -113,7 +113,9 @@ runs:
 
     - name: Install kustodian
       shell: bash
-      run: bun install -g kustodian@${{ inputs.kustodian-version }}
+      run: |
+        bun install -g kustodian@${{ inputs.kustodian-version }}
+        echo "$(bun pm bin -g)" >> "$GITHUB_PATH"
 
     - name: Install project dependencies
       shell: bash


### PR DESCRIPTION
## Summary
- `bun install -g` puts binaries in a directory not on `$PATH` in GitHub Actions runners
- This causes `kustodian: command not found` in both the `kustodian` and `kustodian-pr-diff` actions
- Fix: add `$(bun pm bin -g)` to `$GITHUB_PATH` after global install

## Test plan
- [ ] Re-run failed PR Diff workflow on silverswarm/clusters#169 after merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)