### PR TITLE
fix(action): symlink bun as node for global shims

### DIFF
--- a/action/kustodian-pr-diff/action.yml
+++ b/action/kustodian-pr-diff/action.yml
@@ -45,7 +45,10 @@ runs:
       shell: bash
       run: |
         bun install -g kustodian@${{ inputs.kustodian-version }}
-        echo "$(bun pm bin -g)" >> "$GITHUB_PATH"
+        GLOBAL_BIN="$(bun pm bin -g)"
+        echo "$GLOBAL_BIN" >> "$GITHUB_PATH"
+        # bun global shims use #!/usr/bin/env node — symlink bun as node
+        ln -sf "$(which bun)" "$GLOBAL_BIN/node"
 
     - name: Install project dependencies
       shell: bash

--- a/action/kustodian/action.yml
+++ b/action/kustodian/action.yml
@@ -115,7 +115,10 @@ runs:
       shell: bash
       run: |
         bun install -g kustodian@${{ inputs.kustodian-version }}
-        echo "$(bun pm bin -g)" >> "$GITHUB_PATH"
+        GLOBAL_BIN="$(bun pm bin -g)"
+        echo "$GLOBAL_BIN" >> "$GITHUB_PATH"
+        # bun global shims use #!/usr/bin/env node — symlink bun as node
+        ln -sf "$(which bun)" "$GLOBAL_BIN/node"
 
     - name: Install project dependencies
       shell: bash


### PR DESCRIPTION
## Summary
- Follow-up to #185 — bun global shims use `#!/usr/bin/env node` but GitHub Actions runners with only `oven-sh/setup-bun` don't have `node` on PATH
- Symlinks `bun` as `node` in the global bin directory after install

## Test plan
- [ ] Re-run failed PR Diff workflow on silverswarm/clusters#169

🤖 Generated with [Claude Code](https://claude.com/claude-code)