### PR TITLE
feat: live cluster diff in PR comments

### DIFF
--- a/action/kustodian-pr-diff/action.yml
+++ b/action/kustodian-pr-diff/action.yml
@@ -26,6 +26,10 @@ inputs:
     description: 'Number of days to retain the HTML diff report artifact'
     required: false
     default: '30'
+  kubeconfig:
+    description: 'Base64-encoded kubeconfig for live cluster diff (optional — enables showing actual resource changes)'
+    required: false
+    default: ''
 
 outputs:
   has-changes:
@@ -105,15 +109,81 @@ runs:
       id: diff
       shell: bash
       run: |
-        bun run "${{ github.action_path }}/generate-diff.ts" \
-          /tmp/kustodian-manifests-base \
-          /tmp/kustodian-manifests-pr \
-          /tmp/kustodian-diff-report/index.html \
-          /tmp/kustodian-diff-summary.json \
-          /tmp/kustodian-comment.md
+        ARGS=("--mode" "ci")
+        ARGS+=("/tmp/kustodian-manifests-base")
+        ARGS+=("/tmp/kustodian-manifests-pr")
+        ARGS+=("/tmp/kustodian-diff-report/index.html")
+        ARGS+=("/tmp/kustodian-diff-summary.json")
+        ARGS+=("/tmp/kustodian-comment.md")
+
+        if [ -f "/tmp/kustodian-live-diff.txt" ]; then
+          ARGS+=("--live-diff" "/tmp/kustodian-live-diff.txt")
+        fi
+
+        bun run "${{ github.action_path }}/generate-diff.ts" "${ARGS[@]}"
 
         HAS_CHANGES=$(jq -r 'if .total > 0 then "true" else "false" end' /tmp/kustodian-diff-summary.json)
         echo "has-changes=$HAS_CHANGES" >> "$GITHUB_OUTPUT"
+
+    - name: Setup live diff tools
+      if: inputs.kubeconfig != ''
+      shell: bash
+      run: |
+        # Install kubectl if not present
+        if ! command -v kubectl &>/dev/null; then
+          curl -sLO "https://dl.k8s.io/release/$(curl -Ls https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+          chmod +x kubectl
+          sudo mv kubectl /usr/local/bin/
+        fi
+        # Install flux CLI if not present
+        if ! command -v flux &>/dev/null; then
+          curl -s https://fluxcd.io/install.sh | sudo bash
+        fi
+
+    - name: Configure kubeconfig
+      if: inputs.kubeconfig != ''
+      shell: bash
+      run: |
+        mkdir -p ~/.kube
+        echo "${{ inputs.kubeconfig }}" | base64 -d > ~/.kube/config
+        chmod 600 ~/.kube/config
+
+    - name: Run live cluster diff
+      if: inputs.kubeconfig != ''
+      shell: bash
+      continue-on-error: true
+      working-directory: ${{ inputs.project-path }}
+      run: |
+        ARGS=("diff")
+        ARGS+=("--kubeconfig" "$HOME/.kube/config")
+        if [ -n "${{ inputs.cluster }}" ]; then
+          ARGS+=("--cluster" "${{ inputs.cluster }}")
+        fi
+
+        kustodian "${ARGS[@]}" 2>&1 | tee /tmp/kustodian-live-diff.txt
+
+    - name: Append live diff to comment
+      if: inputs.kubeconfig != '' && hashFiles('/tmp/kustodian-live-diff.txt') != ''
+      shell: bash
+      run: |
+        # Re-generate the comment with live diff included
+        ARGS=("--mode" "ci")
+        ARGS+=("/tmp/kustodian-manifests-base")
+        ARGS+=("/tmp/kustodian-manifests-pr")
+        ARGS+=("/tmp/kustodian-diff-report/index.html")
+        ARGS+=("/tmp/kustodian-diff-summary.json")
+        ARGS+=("/tmp/kustodian-comment.md")
+
+        if [ -s "/tmp/kustodian-live-diff.txt" ]; then
+          ARGS+=("--live-diff" "/tmp/kustodian-live-diff.txt")
+        fi
+
+        bun run "${{ github.action_path }}/generate-diff.ts" "${ARGS[@]}"
+
+    - name: Cleanup kubeconfig
+      if: always() && inputs.kubeconfig != ''
+      shell: bash
+      run: rm -f ~/.kube/config
 
     - name: Upload HTML report
       if: steps.diff.outputs.has-changes == 'true'
@@ -176,4 +246,4 @@ runs:
       run: |
         git worktree remove /tmp/kustodian-base --force 2>/dev/null || true
         rm -rf /tmp/kustodian-manifests-base /tmp/kustodian-manifests-pr 2>/dev/null || true
-        rm -rf /tmp/kustodian-diff-report /tmp/kustodian-diff-summary.json /tmp/kustodian-comment.md 2>/dev/null || true
+        rm -rf /tmp/kustodian-diff-report /tmp/kustodian-diff-summary.json /tmp/kustodian-comment.md /tmp/kustodian-live-diff.txt 2>/dev/null || true

--- a/action/kustodian-pr-diff/generate-diff.ts
+++ b/action/kustodian-pr-diff/generate-diff.ts
@@ -30,9 +30,11 @@ function parse_args(): {
   output_html?: string;
   output_summary?: string;
   output_comment?: string;
+  live_diff_file?: string;
 } {
   const args = process.argv.slice(2);
   let mode: Mode = 'ci';
+  let live_diff_file: string | undefined;
   const positional: string[] = [];
 
   for (let i = 0; i < args.length; i++) {
@@ -42,7 +44,10 @@ function parse_args(): {
         console.error(`Unknown mode: ${mode}. Expected: ci, terminal, comment`);
         process.exit(1);
       }
-      i++; // skip value
+      i++;
+    } else if (args[i] === '--live-diff' && args[i + 1]) {
+      live_diff_file = args[i + 1];
+      i++;
     } else {
       positional.push(args[i] as string);
     }
@@ -53,7 +58,7 @@ function parse_args(): {
   if (!base_dir || !pr_dir) {
     console.error(
       'Usage:\n' +
-        '  generate-diff.ts --mode ci       <base-dir> <pr-dir> <output-html> <output-summary> <output-comment>\n' +
+        '  generate-diff.ts --mode ci       <base-dir> <pr-dir> <output-html> <output-summary> <output-comment> [--live-diff <file>]\n' +
         '  generate-diff.ts --mode terminal <base-dir> <pr-dir>\n' +
         '  generate-diff.ts --mode comment  <base-dir> <pr-dir>',
     );
@@ -67,10 +72,17 @@ function parse_args(): {
     process.exit(1);
   }
 
-  return { mode, base_dir, pr_dir, output_html, output_summary, output_comment };
+  return { mode, base_dir, pr_dir, output_html, output_summary, output_comment, live_diff_file };
 }
 
 const config = parse_args();
+
+// --- Live diff content ---
+
+let live_diff_content = '';
+if (config.live_diff_file && existsSync(config.live_diff_file)) {
+  live_diff_content = readFileSync(config.live_diff_file, 'utf-8').trim();
+}
 
 // --- File discovery ---
 
@@ -358,6 +370,20 @@ function build_comment(): string {
       const block = render_change_block(change);
       parts.push(block);
     }
+  }
+
+  // Append live cluster diff if available
+  if (live_diff_content) {
+    // Strip ANSI escape codes for the markdown comment
+    // biome-ignore lint/suspicious/noControlCharactersInRegex: stripping ANSI escapes requires matching ESC
+    const clean_diff = live_diff_content.replace(/\x1b\[[0-9;]*[a-zA-Z]/g, '');
+
+    parts.push('\n---\n');
+    parts.push('#### 🔴 Live Cluster Diff\n');
+    parts.push('> Actual resource changes compared to the running cluster\n');
+    parts.push(
+      `<details>\n<summary>Show full diff</summary>\n\n\`\`\`diff\n${clean_diff}\n\`\`\`\n\n</details>`,
+    );
   }
 
   let result = parts.join('\n');

--- a/src/cli/commands/diff.ts
+++ b/src/cli/commands/diff.ts
@@ -1,3 +1,4 @@
+import { existsSync } from 'node:fs';
 import { mkdtemp, rm, unlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import * as path from 'node:path';
@@ -51,6 +52,12 @@ export const diff_command = define_command({
       default_value: 'k0s',
     },
     {
+      name: 'kubeconfig',
+      short: 'k',
+      description: 'Path to kubeconfig file (skips provider/SSH)',
+      type: 'string',
+    },
+    {
       name: 'project',
       short: 'p',
       description: 'Path to project root',
@@ -60,6 +67,7 @@ export const diff_command = define_command({
   handler: async (ctx, container) => {
     const cluster_filter = ctx.options['cluster'] as string | undefined;
     const provider_name = ctx.options['provider'] as string;
+    const kubeconfig_path = ctx.options['kubeconfig'] as string | undefined;
     const project_path = (ctx.options['project'] as string) || process.cwd();
 
     console.log('\n━━━ Kustodian Diff ━━━');
@@ -79,8 +87,6 @@ export const diff_command = define_command({
       const oci_registry_secret_name = defaults.oci_registry_secret_name;
 
       console.log(`\n━━━ Cluster: ${cluster_name} ━━━`);
-      console.log(`  Provider: ${provider_name}`);
-      console.log(`  ✓ Loaded ${loaded_cluster.nodes.length} nodes`);
 
       if (!loaded_cluster.cluster.spec.oci) {
         process.exitCode = 2;
@@ -99,25 +105,44 @@ export const diff_command = define_command({
         return validation_result;
       }
 
-      // Resolve provider from plugin registry (before try block — no cleanup needed)
-      const registry_result = container.resolve(PLUGIN_REGISTRY_ID);
-      if (!is_success(registry_result)) {
-        return registry_result;
-      }
-      const provider_result = resolve_provider(
-        registry_result.value,
-        loaded_cluster,
-        provider_name,
-      );
-      if (!is_success(provider_result)) {
-        return provider_result;
-      }
-
+      // Resolve kubeconfig: either from --kubeconfig flag or via provider SSH
+      let resolved_kubeconfig: string;
       let temp_kubeconfig: string | undefined;
-      let temp_flux_kustomization_dir: string | undefined;
-      const provider: ClusterProviderType = provider_result.value;
+      let provider: ClusterProviderType | undefined;
 
-      try {
+      if (kubeconfig_path) {
+        // Use the provided kubeconfig directly
+        if (!existsSync(kubeconfig_path)) {
+          process.exitCode = 2;
+          return {
+            success: false as const,
+            error: {
+              code: 'INVALID_CONFIG',
+              message: `Kubeconfig file not found: ${kubeconfig_path}`,
+            },
+          };
+        }
+        console.log(`  Kubeconfig: ${kubeconfig_path}`);
+        resolved_kubeconfig = kubeconfig_path;
+      } else {
+        // Resolve provider from plugin registry
+        console.log(`  Provider: ${provider_name}`);
+        console.log(`  ✓ Loaded ${loaded_cluster.nodes.length} nodes`);
+
+        const registry_result = container.resolve(PLUGIN_REGISTRY_ID);
+        if (!is_success(registry_result)) {
+          return registry_result;
+        }
+        const provider_result = resolve_provider(
+          registry_result.value,
+          loaded_cluster,
+          provider_name,
+        );
+        if (!is_success(provider_result)) {
+          return provider_result;
+        }
+        provider = provider_result.value;
+
         const node_list = build_node_list(loaded_cluster);
 
         const validate_result = provider.validate(node_list);
@@ -138,7 +163,6 @@ export const diff_command = define_command({
         );
         await writeFile(temp_kubeconfig, kubeconfig_result.value as string, 'utf-8');
 
-        // Rename kubeconfig entries to cluster-scoped names
         const kubeconfig_manager = create_kubeconfig_manager();
         const rename_result = await kubeconfig_manager.rename_entries(
           temp_kubeconfig,
@@ -149,7 +173,13 @@ export const diff_command = define_command({
           return rename_result;
         }
 
-        const client_options = { kubeconfig: temp_kubeconfig };
+        resolved_kubeconfig = temp_kubeconfig;
+      }
+
+      let temp_flux_kustomization_dir: string | undefined;
+
+      try {
+        const client_options = { kubeconfig: resolved_kubeconfig };
         const kubectl_client = create_kubectl_client(client_options);
         const flux_client = create_flux_client(client_options);
 
@@ -332,7 +362,7 @@ export const diff_command = define_command({
           }
         }
       } finally {
-        await provider?.cleanup?.();
+        if (provider) await provider.cleanup?.();
         if (temp_kubeconfig) {
           await unlink(temp_kubeconfig).catch(() => undefined);
         }


### PR DESCRIPTION
## Summary
- Add `--kubeconfig` flag to `kustodian diff` — skips provider/SSH and uses the file directly
- PR diff action accepts optional `kubeconfig` input (base64-encoded)
- When provided, runs `kustodian diff` against the live cluster
- Appends actual resource changes (Deployments, ConfigMaps, Services) to the PR comment

## Test plan
- [ ] Update silverswarm/clusters PR diff workflow with kubeconfig secret
- [ ] Verify live diff appears in PR comment on clusters#169

🤖 Generated with [Claude Code](https://claude.com/claude-code)