### PR TITLE
fix: format renovate.json to satisfy biome lint

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,1 +1,4 @@
-{"$schema":"https://docs.renovatebot.com/renovate-schema.json","extends":["local>lucasilverentand/.github"]}
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["local>lucasilverentand/.github"]
+}


### PR DESCRIPTION
## Summary

- Format `renovate.json` (multi-line, trailing newline) so `biome check` passes.

## Why

CI on main has been red since e858088 ("chore: add renovate config") because that commit added the file as a single-line JSON without a trailing newline, which Biome rejects. This means the `Release` workflow has not run since #193 landed, and release-please has not been able to open a release PR for v1.15.0 (which would publish #193's per-cluster summary table feature to npm).

## Test plan

- [x] `bunx biome check renovate.json` passes locally
- [ ] CI passes on this PR
- [ ] After merge, `Release` workflow runs and release-please opens a v1.15.0 PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)