### PR TITLE
ci: pin nested composite actions

### DIFF
--- a/action/kustodian-pr-diff/action.yml
+++ b/action/kustodian-pr-diff/action.yml
@@ -39,7 +39,7 @@ runs:
   using: 'composite'
   steps:
     - name: Setup Bun
-      uses: oven-sh/setup-bun@v2
+      uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
     - name: Install kustodian
       shell: bash
@@ -131,7 +131,7 @@ runs:
 
     - name: Comment on PR
       if: github.event_name == 'pull_request'
-      uses: actions/github-script@v7
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
       with:
         github-token: ${{ inputs.github-token }}
         script: |

--- a/action/kustodian/action.yml
+++ b/action/kustodian/action.yml
@@ -109,7 +109,7 @@ runs:
         esac
 
     - name: Setup Bun
-      uses: oven-sh/setup-bun@v2
+      uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
     - name: Install kustodian
       shell: bash
@@ -130,7 +130,7 @@ runs:
 
     - name: Setup Flux CLI
       if: inputs.command == 'apply' || inputs.command == 'diff' || inputs.command == 'status'
-      uses: fluxcd/flux2/action@main
+      uses: fluxcd/flux2/action@abb86f161b5e6d037424db3ebdc02f27e6f95fca # main
 
     - name: Configure kubeconfig
       if: inputs.kubeconfig != ''


### PR DESCRIPTION
## Summary

- Pin nested action dependencies in `action/kustodian` to full-length commit SHAs.
- Pin nested action dependencies in `action/kustodian-pr-diff` to full-length commit SHAs.
- Keep comments showing the original human-readable tag or branch refs.

Closes #202.

## Verification

- `bun -e 'const fs=require("fs"); const files=["action/kustodian/action.yml","action/kustodian-pr-diff/action.yml"]; let bad=[]; for (const file of files) for (const [i,line] of fs.readFileSync(file,"utf8").split("\n").entries()) { const m=line.match(/uses:\s*([^\s#]+)\s*(?:#.*)?$/); if (m) { const ref=m[1].split("@").pop(); if (!/^[0-9a-f]{40}$/.test(ref)) bad.push(`${file}:${i+1}: ${m[1]}`); } } if (bad.length) { console.error(bad.join("\n")); process.exit(1); } console.log("All nested action refs are full-length SHAs.");'`
- `bun run lint`
- pre-commit: `biome check .`
- pre-commit: `tsc --noEmit`