### PR TITLE
feat: consume versioned templates from external sources

### DIFF
--- a/docs/src/content/docs/concepts/templates.mdx
+++ b/docs/src/content/docs/concepts/templates.mdx
@@ -151,6 +151,37 @@ spec:
         - kustomization: monitoring/prometheus-instance
 ```
 
+## External template sources
+
+Templates do not have to live in the project repository. List them under
+`spec.template_sources` in `kustodian.yaml` and Kustodian will fetch them
+into a local cache and merge them with the templates in `templates/`:
+
+```yaml
+apiVersion: kustodian.io/v1
+kind: Project
+metadata:
+  name: my-infra
+spec:
+  template_sources:
+    # Pin a versioned template from a GitHub repo (shorthand form)
+    - name: nginx
+      github: lucasilverentand/kustodian-templates@v1.0.0:nginx
+
+    # Or use the explicit Git form for any host
+    - name: monitoring
+      git:
+        url: https://git.example.com/templates.git
+        ref:
+          tag: v2.3.4
+```
+
+A source repo can host either a single template (a `template.yaml` at the
+root) or many (one `template.yaml` per subdirectory). Tag and commit refs
+are immutable and cached forever; branch refs honour the optional `ttl`
+(default 1h). See the [Project reference](/reference/config/project/) for
+the full schema.
+
 ## Next Steps
 
 - [Creating Templates](/guides/creating-templates/) - Step-by-step guide

--- a/docs/src/content/docs/reference/config/project.mdx
+++ b/docs/src/content/docs/reference/config/project.mdx
@@ -12,6 +12,10 @@ apiVersion: kustodian.io/v1
 kind: Project
 metadata:
   name: <project-name>
+spec:
+  template_sources: # optional, see "External template sources"
+    - name: <source-name>
+      github: <owner>/<repo>@<ref>
 ```
 
 ## Fields
@@ -74,6 +78,76 @@ kind: Project
 metadata:
   name: production-infrastructure
 ```
+
+## External template sources
+
+`spec.template_sources` lets you consume templates that live in another Git
+repository, an HTTP archive, or an OCI registry. Each entry is fetched into
+the project's local cache (`.kustodian/templates-cache`) and merged with the
+templates found under `templates/`.
+
+A single source can host either:
+
+- **One template** — `template.yaml` at the root of the source path.
+- **Many templates** — each subdirectory contains its own `template.yaml`.
+
+Template names must be unique across all sources and the local `templates/`
+directory.
+
+### GitHub source
+
+```yaml
+spec:
+  template_sources:
+    # Shorthand: owner/repo@<branch|tag|commit>[:path]
+    - name: nginx
+      github: lucasilverentand/kustodian-templates@v1.0.0:nginx
+
+    # Object form
+    - name: monitoring
+      github:
+        repo: lucasilverentand/monitoring-templates
+        ref:
+          tag: v2.3.4
+        path: kube-prometheus-stack
+      ttl: 1h
+```
+
+The shorthand parser infers the ref kind:
+
+- 40-character hex strings → `commit`
+- Semver-shaped strings (e.g. `v1.2.3`, `1.0`) → `tag`
+- Anything else → `branch`
+
+### Git source
+
+```yaml
+spec:
+  template_sources:
+    - name: shared
+      git:
+        url: https://git.example.com/templates.git
+        ref:
+          tag: v1.0.0
+        path: production
+```
+
+Exactly one of `ref.branch`, `ref.tag`, or `ref.commit` must be set. Tags and
+commits are immutable and cached forever; branches are mutable and refreshed
+according to `ttl` (default 1h).
+
+### Working with sources
+
+```bash
+kustodian sources list           # show configured sources
+kustodian sources fetch          # populate the cache
+kustodian sources fetch --force  # refresh, ignoring TTL
+kustodian sources versions <name>
+kustodian sources cache info
+```
+
+Commands that load templates (`apply`, `diff`, `validate`, `update`) fetch
+configured sources automatically and report cache hits in their output.
 
 ## Location
 

--- a/src/cli/commands/sources.ts
+++ b/src/cli/commands/sources.ts
@@ -3,7 +3,7 @@ import * as path from 'node:path';
 import { parse } from 'yaml';
 import { failure, success } from '../../core/index.js';
 import { find_project_root } from '../../loader/index.js';
-import type { TemplateSourceType } from '../../schema/index.js';
+import { type TemplateSourceType, validate_project } from '../../schema/index.js';
 import {
   DEFAULT_CACHE_DIR,
   create_cache_manager,
@@ -14,26 +14,26 @@ import {
 import { define_command } from '../command.js';
 
 /**
- * Project configuration with template sources.
- */
-interface ProjectConfigType {
-  spec?: {
-    template_sources?: TemplateSourceType[];
-  };
-}
-
-/**
- * Reads template sources from project config.
+ * Reads and validates template sources from project config.
+ *
+ * Uses the project schema so GitHub shorthand and other refinements are
+ * applied uniformly across `apply`, `diff`, and the `sources` commands.
  */
 async function get_template_sources(project_root: string): Promise<TemplateSourceType[]> {
   const config_path = path.join(project_root, 'kustodian.yaml');
+  let raw: unknown;
   try {
     const content = await fs.readFile(config_path, 'utf-8');
-    const config = parse(content) as ProjectConfigType;
-    return config?.spec?.template_sources ?? [];
+    raw = parse(content);
   } catch {
     return [];
   }
+
+  const validation = validate_project(raw);
+  if (!validation.success) {
+    return [];
+  }
+  return validation.data.spec?.template_sources ?? [];
 }
 
 /**
@@ -205,10 +205,24 @@ export const sources_command = define_command({
 
           console.log('Configured sources:\n');
           for (const source of sources) {
-            const type = source.git ? 'git' : source.http ? 'http' : source.oci ? 'oci' : 'unknown';
-            console.log(`  ${source.name} (${type})`);
+            const display_type = source.github
+              ? 'github'
+              : source.git
+                ? 'git'
+                : source.http
+                  ? 'http'
+                  : source.oci
+                    ? 'oci'
+                    : 'unknown';
+            console.log(`  ${source.name} (${display_type})`);
 
-            if (source.git) {
+            if (source.github) {
+              const gh = source.github;
+              const ref = gh.ref.tag ?? gh.ref.branch ?? gh.ref.commit;
+              console.log(`    Repo: ${gh.repo}`);
+              console.log(`    Ref: ${ref}`);
+              if (gh.path) console.log(`    Path: ${gh.path}`);
+            } else if (source.git) {
               const ref = source.git.ref.tag ?? source.git.ref.branch ?? source.git.ref.commit;
               console.log(`    URL: ${source.git.url}`);
               console.log(`    Ref: ${ref}`);

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -98,7 +98,7 @@ export const update_command = define_command({
       return root_result;
     }
 
-    const project_result = await load_project(root_result.value);
+    const project_result = await load_project(root_result.value, { fetch_sources: true });
     if (!is_success(project_result)) {
       return project_result;
     }

--- a/src/cli/commands/validate.ts
+++ b/src/cli/commands/validate.ts
@@ -50,7 +50,7 @@ export const validate_command = define_command({
 
     // Load project
     console.log('Loading project...');
-    const project_result = await load_project(project_root);
+    const project_result = await load_project(project_root, { fetch_sources: true });
     if (!project_result.success) {
       console.error(`Validation failed: ${project_result.error.message}`);
       return project_result;

--- a/src/cli/utils/project.ts
+++ b/src/cli/utils/project.ts
@@ -22,12 +22,25 @@ export interface LoadedProjectType {
 }
 
 /**
+ * Options for `load_and_resolve_project`.
+ *
+ * `fetch_sources` defaults to `true` so commands like apply/diff/validate
+ * transparently pull templates from configured external sources. Pass
+ * `false` to skip the network and use only local templates.
+ */
+export interface LoadAndResolveOptions {
+  fetch_sources?: boolean;
+  force_refresh?: boolean;
+}
+
+/**
  * Loads a project and resolves target clusters in one step.
  * Handles find_project_root → load_project → find_cluster with console logging.
  */
 export async function load_and_resolve_project(
   project_path: string,
   cluster_filter?: string,
+  options?: LoadAndResolveOptions,
 ): Promise<ResultType<LoadedProjectType, KustodianErrorType>> {
   console.log('\nLoading project configuration...');
   const root_result = await find_project_root(project_path);
@@ -39,14 +52,33 @@ export async function load_and_resolve_project(
   const project_root = root_result.value;
   console.log(`  → Project root: ${project_root}`);
 
-  const project_result = await load_project(project_root);
+  const fetch_sources = options?.fetch_sources ?? true;
+  const load_options: { fetch_sources: boolean; force_refresh?: boolean } = { fetch_sources };
+  if (options?.force_refresh !== undefined) {
+    load_options.force_refresh = options.force_refresh;
+  }
+  const project_result = await load_project(project_root, load_options);
   if (!is_success(project_result)) {
     console.error(`  ✗ Error: ${project_result.error.message}`);
     return project_result;
   }
 
   const project = project_result.value;
-  console.log(`  ✓ Loaded ${project.templates.length} templates`);
+  if (project.resolved_sources && project.resolved_sources.length > 0) {
+    for (const src of project.resolved_sources) {
+      const status = src.from_cache ? '(cached)' : '(fetched)';
+      console.log(`  → Source ${src.name} @ ${src.version} ${status}`);
+    }
+  }
+  const local_count = project.templates.filter((t) => !t.source_name).length;
+  const sourced_count = project.templates.length - local_count;
+  if (sourced_count > 0) {
+    console.log(
+      `  ✓ Loaded ${project.templates.length} templates (${local_count} local, ${sourced_count} from sources)`,
+    );
+  } else {
+    console.log(`  ✓ Loaded ${project.templates.length} templates`);
+  }
 
   let target_clusters: LoadedClusterType[];
   if (cluster_filter) {

--- a/src/loader/project.ts
+++ b/src/loader/project.ts
@@ -39,10 +39,15 @@ export const StandardDirs = {
 
 /**
  * Loaded template with its source path.
+ *
+ * `source_name` is set when the template was fetched from a configured
+ * external source (`spec.template_sources` in `kustodian.yaml`); it is
+ * absent for templates loaded from the local `templates/` directory.
  */
 export interface LoadedTemplateType {
   path: string;
   template: TemplateType;
+  source_name?: string;
 }
 
 /**
@@ -83,6 +88,10 @@ export function filter_clusters(
 
 /**
  * A fully loaded Kustodian project.
+ *
+ * `templates` contains both local templates (from `templates/`) and any
+ * templates fetched from `spec.template_sources` when sources were
+ * resolved. Source-fetched templates carry a `source_name`.
  */
 export interface ProjectType {
   root: string;
@@ -90,6 +99,32 @@ export interface ProjectType {
   templates: LoadedTemplateType[];
   clusters: LoadedClusterType[];
   profiles: Map<string, NodeProfileType>;
+  /** Resolved external sources, when sources were fetched. */
+  resolved_sources?: ResolvedSourceSummaryType[];
+}
+
+/**
+ * Summary of a resolved external source, attached to ProjectType when
+ * sources were fetched. Mirrors the shape needed by callers without
+ * pulling the full `sources` package types into the loader interface.
+ */
+export interface ResolvedSourceSummaryType {
+  name: string;
+  version: string;
+  from_cache: boolean;
+  fetched_at: Date;
+  path: string;
+}
+
+/**
+ * Options for `load_project`. By default no network I/O is performed —
+ * pass `fetch_sources: true` to also fetch and merge templates from
+ * `spec.template_sources`.
+ */
+export interface LoadProjectOptionsType {
+  fetch_sources?: boolean;
+  cache_dir?: string;
+  force_refresh?: boolean;
 }
 
 /**
@@ -268,8 +303,15 @@ export async function load_cluster(
 
 /**
  * Recursively finds all directories containing template.yaml files.
+ *
+ * Treats a directory as a template root as soon as it contains a
+ * `template.yaml`, and stops descending — kustomization sub-directories
+ * referenced from the template are not themselves templates.
+ *
+ * Exported so source-fetched repos (which may be single-template at the
+ * root or multi-template nested) can reuse the same discovery rules.
  */
-async function find_template_directories(dir: string): Promise<string[]> {
+export async function find_template_directories(dir: string): Promise<string[]> {
   const template_path = path.join(dir, StandardFiles.TEMPLATE);
 
   // If this directory has a template.yaml, return it
@@ -367,9 +409,16 @@ export async function load_all_clusters(
 
 /**
  * Loads a complete Kustodian project.
+ *
+ * Pass `options.fetch_sources` to also pull templates from any external
+ * sources configured under `spec.template_sources` in `kustodian.yaml`.
+ * Source-fetched templates are merged into `templates` and tagged with
+ * `source_name`; resolved source metadata is attached as
+ * `resolved_sources`.
  */
 export async function load_project(
   project_root: string,
+  options?: LoadProjectOptionsType,
 ): Promise<ResultType<ProjectType, KustodianErrorType>> {
   // Verify project exists
   const project_file = path.join(project_root, StandardFiles.PROJECT);
@@ -394,7 +443,7 @@ export async function load_project(
     return profiles_result;
   }
 
-  // Load templates
+  // Load local templates
   const templates_result = await load_all_templates(project_root);
   if (!is_success(templates_result)) {
     return templates_result;
@@ -406,15 +455,82 @@ export async function load_project(
     return clusters_result;
   }
 
+  const all_templates: LoadedTemplateType[] = [...templates_result.value];
+  let resolved_sources: ResolvedSourceSummaryType[] | undefined;
+
+  // Fetch external sources when requested
+  const sources = project_config?.spec?.template_sources ?? [];
+  if (options?.fetch_sources && sources.length > 0) {
+    // Dynamic import to avoid pulling the network/cache stack into callers
+    // that just need local project loading.
+    const { load_templates_from_sources, DEFAULT_CACHE_DIR } = await import('../sources/index.js');
+    const cache_dir = options.cache_dir ?? path.join(project_root, DEFAULT_CACHE_DIR);
+
+    const fetch_options: { cache_dir: string; force_refresh?: boolean } = { cache_dir };
+    if (options.force_refresh !== undefined) {
+      fetch_options.force_refresh = options.force_refresh;
+    }
+    const sources_result = await load_templates_from_sources(sources, fetch_options);
+    if (!is_success(sources_result)) {
+      return sources_result;
+    }
+
+    // Detect name collisions between local and sourced templates
+    const local_names = new Set(templates_result.value.map((t) => t.template.metadata.name));
+    const conflicts: string[] = [];
+    for (const sourced of sources_result.value.templates) {
+      if (local_names.has(sourced.template.metadata.name)) {
+        conflicts.push(
+          `${sourced.template.metadata.name} (from source '${sourced.source_name}' clashes with local template)`,
+        );
+        continue;
+      }
+      all_templates.push({
+        path: sourced.path,
+        template: sourced.template,
+        source_name: sourced.source_name,
+      });
+    }
+
+    // Detect collisions between sourced templates from different sources
+    const seen = new Map<string, string>();
+    for (const sourced of sources_result.value.templates) {
+      const existing = seen.get(sourced.template.metadata.name);
+      if (existing && existing !== sourced.source_name) {
+        conflicts.push(
+          `${sourced.template.metadata.name} (provided by both source '${existing}' and source '${sourced.source_name}')`,
+        );
+      }
+      seen.set(sourced.template.metadata.name, sourced.source_name);
+    }
+
+    if (conflicts.length > 0) {
+      return failure(
+        Errors.validation_error(`Template name conflicts:\n  ${conflicts.join('\n  ')}`),
+      );
+    }
+
+    resolved_sources = sources_result.value.resolved.map((r) => ({
+      name: r.source.name,
+      version: r.fetch_result.version,
+      from_cache: r.fetch_result.from_cache,
+      fetched_at: r.fetch_result.fetched_at,
+      path: r.fetch_result.path,
+    }));
+  }
+
   const result: ProjectType = {
     root: project_root,
-    templates: templates_result.value,
+    templates: all_templates,
     clusters: clusters_result.value,
     profiles: profiles_result.value,
   };
 
   if (project_config) {
     result.config = project_config;
+  }
+  if (resolved_sources) {
+    result.resolved_sources = resolved_sources;
   }
 
   return success(result);

--- a/src/schema/project.ts
+++ b/src/schema/project.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { api_version_schema, metadata_schema } from './common.js';
+import { template_source_schema } from './sources.js';
 
 /**
  * Project-level defaults that apply to all clusters.
@@ -27,6 +28,12 @@ export type ProjectDefaultsType = z.infer<typeof project_defaults_schema>;
  */
 export const project_spec_schema = z.object({
   defaults: project_defaults_schema.optional(),
+  /**
+   * External template sources (Git, GitHub, HTTP, OCI). Each entry is
+   * fetched, cached, and merged with templates loaded from the local
+   * `templates/` directory. Names must be unique across all sources.
+   */
+  template_sources: z.array(template_source_schema).optional(),
 });
 
 export type ProjectSpecType = z.infer<typeof project_spec_schema>;

--- a/src/schema/sources.ts
+++ b/src/schema/sources.ts
@@ -27,6 +27,93 @@ export const git_source_schema = z.object({
 export type GitSourceType = z.infer<typeof git_source_schema>;
 
 /**
+ * Object form of a GitHub source: `{ repo: 'owner/name', ref: { tag: 'v1' }, path? }`.
+ *
+ * The repo is `owner/name`. Sub-paths into the repo are passed as `path`,
+ * which lets a single repo host either one template (root) or many (one
+ * per subdirectory).
+ */
+export const github_source_object_schema = z.object({
+  repo: z.string().regex(/^[^/\s]+\/[^/\s]+$/, "GitHub repo must be in the form 'owner/name'"),
+  ref: git_ref_schema,
+  path: z.string().optional(),
+});
+
+export type GitHubSourceObjectType = z.infer<typeof github_source_object_schema>;
+
+/**
+ * Parses a GitHub shorthand string into the object form.
+ *
+ * Accepted forms:
+ * - `owner/repo@v1.2.3`         — tag (anything that looks like a semver tag)
+ * - `owner/repo@main`           — branch (any other ref)
+ * - `owner/repo@<40-hex>`       — full commit SHA
+ * - `owner/repo@ref:sub/path`   — with sub-path inside the repo
+ *
+ * The ref kind (tag vs branch vs commit) is inferred:
+ * - 40-character hex strings are treated as commits
+ * - strings matching `v?\d+...` are treated as tags
+ * - everything else is treated as a branch
+ */
+function parse_github_shorthand(input: string): GitHubSourceObjectType {
+  const at = input.indexOf('@');
+  if (at < 0) {
+    throw new Error(
+      `GitHub shorthand must include a ref: 'owner/repo@<branch|tag|commit>[:path]', got '${input}'`,
+    );
+  }
+
+  const repo = input.slice(0, at);
+  const rest = input.slice(at + 1);
+
+  // Sub-path is separated by ':' after the ref
+  const colon = rest.indexOf(':');
+  const ref_str = colon < 0 ? rest : rest.slice(0, colon);
+  const path = colon < 0 ? undefined : rest.slice(colon + 1);
+
+  if (!repo || !ref_str) {
+    throw new Error(
+      `GitHub shorthand must be 'owner/repo@<branch|tag|commit>[:path]', got '${input}'`,
+    );
+  }
+
+  let ref: GitRefType;
+  if (/^[0-9a-f]{40}$/i.test(ref_str)) {
+    ref = { commit: ref_str };
+  } else if (/^v?\d+(\.\d+)*([.-].+)?$/.test(ref_str)) {
+    ref = { tag: ref_str };
+  } else {
+    ref = { branch: ref_str };
+  }
+
+  return path ? { repo, ref, path } : { repo, ref };
+}
+
+/**
+ * GitHub source configuration. Accepts either a structured object or a
+ * shorthand string of the form `owner/repo@ref[:path]`.
+ *
+ * Internally normalized to a Git source pointing at
+ * `https://github.com/<owner>/<repo>.git`.
+ */
+export const github_source_schema = z.union([
+  github_source_object_schema,
+  z.string().transform((value, ctx): GitHubSourceObjectType => {
+    try {
+      return parse_github_shorthand(value);
+    } catch (error) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: error instanceof Error ? error.message : 'Invalid GitHub shorthand',
+      });
+      return z.NEVER;
+    }
+  }),
+]);
+
+export type GitHubSourceType = z.infer<typeof github_source_schema>;
+
+/**
  * HTTP archive source configuration for fetching templates from URLs.
  * Supports tar.gz and zip archives.
  */
@@ -64,18 +151,19 @@ export const duration_schema = z.string().regex(/^(\d+)(m|h|d)$/, {
 
 /**
  * Template source configuration - union of all source types.
- * Exactly one of git, http, or oci must be specified.
+ * Exactly one of git, github, http, or oci must be specified.
  */
 export const template_source_schema = z
   .object({
     name: z.string().min(1),
     git: git_source_schema.optional(),
+    github: github_source_schema.optional(),
     http: http_source_schema.optional(),
     oci: oci_source_schema.optional(),
     ttl: duration_schema.optional(),
   })
-  .refine((data) => [data.git, data.http, data.oci].filter(Boolean).length === 1, {
-    message: "Exactly one of 'git', 'http', or 'oci' must be specified",
+  .refine((data) => [data.git, data.github, data.http, data.oci].filter(Boolean).length === 1, {
+    message: "Exactly one of 'git', 'github', 'http', or 'oci' must be specified",
   });
 
 export type TemplateSourceType = z.infer<typeof template_source_schema>;
@@ -87,6 +175,15 @@ export function is_git_source(
   source: TemplateSourceType,
 ): source is TemplateSourceType & { git: GitSourceType } {
   return source.git !== undefined;
+}
+
+/**
+ * Type guard for GitHub sources.
+ */
+export function is_github_source(
+  source: TemplateSourceType,
+): source is TemplateSourceType & { github: GitHubSourceType } {
+  return source.github !== undefined;
 }
 
 /**
@@ -111,25 +208,58 @@ export function is_oci_source(
  * Determines if a source reference is mutable (requires TTL-based refresh).
  * - Git branches: mutable
  * - Git tags/commits: immutable
+ * - GitHub branches: mutable
+ * - GitHub tags/commits: immutable
  * - HTTP with checksum: immutable
  * - HTTP without checksum: mutable
  * - OCI 'latest' tag: mutable
  * - OCI other tags/digests: immutable
  */
 export function is_mutable_source(source: TemplateSourceType): boolean {
-  if (is_git_source(source)) {
-    return source.git.ref.branch !== undefined;
+  const normalized = normalize_template_source(source);
+
+  if (is_git_source(normalized)) {
+    return normalized.git.ref.branch !== undefined;
   }
 
-  if (is_http_source(source)) {
-    return source.http.checksum === undefined;
+  if (is_http_source(normalized)) {
+    return normalized.http.checksum === undefined;
   }
 
-  if (is_oci_source(source)) {
-    return source.oci.tag === 'latest' && source.oci.digest === undefined;
+  if (is_oci_source(normalized)) {
+    return normalized.oci.tag === 'latest' && normalized.oci.digest === undefined;
   }
 
   return true;
+}
+
+/**
+ * Normalizes a template source so downstream code only sees `git`, `http`,
+ * or `oci` variants. GitHub sources are rewritten to a Git source pointing
+ * at `https://github.com/<owner>/<repo>.git`.
+ *
+ * Idempotent: passing an already-normalized source returns it unchanged.
+ */
+export function normalize_template_source(source: TemplateSourceType): TemplateSourceType {
+  if (!is_github_source(source)) {
+    return source;
+  }
+
+  const gh = source.github;
+
+  const git: GitSourceType = {
+    url: `https://github.com/${gh.repo}.git`,
+    ref: gh.ref,
+    ...(gh.path !== undefined ? { path: gh.path } : {}),
+  };
+
+  const normalized: TemplateSourceType = {
+    name: source.name,
+    git,
+    ...(source.ttl !== undefined ? { ttl: source.ttl } : {}),
+  };
+
+  return normalized;
 }
 
 /**

--- a/src/sources/fetchers/git.ts
+++ b/src/sources/fetchers/git.ts
@@ -19,6 +19,25 @@ const exec_file_async = promisify(execFile);
 const DEFAULT_TIMEOUT = 120_000; // 2 minutes
 
 /**
+ * Returns a copy of `process.env` with any `GIT_*` variables removed.
+ *
+ * Without this, calling `git clone` from inside another git operation
+ * (e.g. when kustodian is invoked from a Git pre-push hook) would
+ * inherit `GIT_DIR`, `GIT_WORK_TREE`, `GIT_INDEX_FILE`, etc. and
+ * misbehave — for instance, attempting to clone into the outer
+ * repository's index instead of the requested destination.
+ */
+function git_subprocess_env(): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (value !== undefined && !key.startsWith('GIT_')) {
+      env[key] = value;
+    }
+  }
+  return env;
+}
+
+/**
  * Creates a Git source fetcher.
  */
 export function create_git_fetcher(): SourceFetcherType {
@@ -96,7 +115,7 @@ class GitFetcher implements SourceFetcherType {
       // Inline exec_file_async for clone so the sanitized URL doesn't flow
       // through a generic wrapper — this lets static analysis see the full call.
       try {
-        await exec_file_async('git', clone_args, { timeout });
+        await exec_file_async('git', clone_args, { timeout, env: git_subprocess_env() });
       } catch (error) {
         if (error instanceof Error && 'killed' in error && (error as { killed?: boolean }).killed) {
           return failure(Errors.source_timeout(source.name, timeout));
@@ -107,7 +126,11 @@ class GitFetcher implements SourceFetcherType {
       // If fetching a specific commit, checkout that commit
       if (is_commit) {
         try {
-          await exec_file_async('git', ['checkout', '--', git_ref], { timeout, cwd: temp_dir });
+          await exec_file_async('git', ['checkout', '--', git_ref], {
+            timeout,
+            cwd: temp_dir,
+            env: git_subprocess_env(),
+          });
         } catch (error) {
           if (
             error instanceof Error &&
@@ -126,6 +149,7 @@ class GitFetcher implements SourceFetcherType {
         const { stdout } = await exec_file_async('git', ['rev-parse', 'HEAD'], {
           timeout,
           cwd: temp_dir,
+          env: git_subprocess_env(),
         });
         commit_sha = stdout.trim();
       } catch (error) {
@@ -188,6 +212,7 @@ class GitFetcher implements SourceFetcherType {
         ['ls-remote', '--tags', '--heads', '--', url],
         {
           timeout: DEFAULT_TIMEOUT,
+          env: git_subprocess_env(),
         },
       );
 

--- a/src/sources/fetchers/index.ts
+++ b/src/sources/fetchers/index.ts
@@ -15,6 +15,7 @@ import {
   is_git_source,
   is_http_source,
   is_oci_source,
+  normalize_template_source,
 } from '../../schema/index.js';
 import { create_git_fetcher } from './git.js';
 import { create_http_fetcher } from './http.js';
@@ -22,18 +23,21 @@ import { create_oci_fetcher } from './oci.js';
 import type { SourceFetcherType } from './types.js';
 
 /**
- * Gets the appropriate fetcher for a source type.
+ * Gets the appropriate fetcher for a source type. The source is normalized
+ * first, so GitHub sources are dispatched to the Git fetcher.
  */
 export function get_fetcher_for_source(
   source: TemplateSourceType,
 ): ResultType<SourceFetcherType, KustodianErrorType> {
-  if (is_git_source(source)) {
+  const normalized = normalize_template_source(source);
+
+  if (is_git_source(normalized)) {
     return success(create_git_fetcher());
   }
-  if (is_http_source(source)) {
+  if (is_http_source(normalized)) {
     return success(create_http_fetcher());
   }
-  if (is_oci_source(source)) {
+  if (is_oci_source(normalized)) {
     return success(create_oci_fetcher());
   }
   return failure(

--- a/src/sources/loader.ts
+++ b/src/sources/loader.ts
@@ -6,7 +6,11 @@ import {
   is_success,
   success,
 } from '../core/index.js';
-import { type LoadedTemplateType, list_directories, load_template } from '../loader/index.js';
+import {
+  type LoadedTemplateType,
+  find_template_directories,
+  load_template,
+} from '../loader/index.js';
 import type { TemplateSourceType } from '../schema/index.js';
 import { type CreateResolverOptionsType, create_source_resolver } from './resolver.js';
 import type { FetchOptionsType, ResolvedSourceType } from './types.js';
@@ -92,20 +96,20 @@ export async function load_templates_from_sources(
 
 /**
  * Loads all templates from a directory path.
- * Looks for subdirectories containing template.yaml files.
+ *
+ * Walks the tree looking for `template.yaml` files. Stops at the first
+ * one found in a given branch, which lets the same logic handle both:
+ *
+ *   - Single-template repos (root has `template.yaml`)
+ *   - Multi-template repos (each subdirectory under the root or some
+ *     prefix path holds its own `template.yaml`)
  */
 async function load_templates_from_path(
   source_path: string,
 ): Promise<ResultType<LoadedTemplateType[], KustodianErrorType>> {
-  // List all subdirectories that might be templates
-  const dirs_result = await list_directories(source_path);
+  const template_dirs = await find_template_directories(source_path);
 
-  if (!is_success(dirs_result)) {
-    // Check if this path itself is a template
-    const direct_result = await load_template(source_path);
-    if (is_success(direct_result)) {
-      return success([direct_result.value]);
-    }
+  if (template_dirs.length === 0) {
     return failure({
       code: 'NOT_FOUND',
       message: `No templates found in ${source_path}`,
@@ -115,16 +119,13 @@ async function load_templates_from_path(
   const templates: LoadedTemplateType[] = [];
   const errors: string[] = [];
 
-  for (const dir of dirs_result.value) {
+  for (const dir of template_dirs) {
     const result = await load_template(dir);
     if (is_success(result)) {
       templates.push(result.value);
     } else {
-      // Only log errors for directories that look like templates
-      // (i.e., they have a template.yaml that failed validation)
-      if (result.error.code === 'SCHEMA_VALIDATION_ERROR') {
-        errors.push(`${path.basename(dir)}: ${result.error.message}`);
-      }
+      const relative = path.relative(source_path, dir) || '.';
+      errors.push(`${relative}: ${result.error.message}`);
     }
   }
 

--- a/src/sources/resolver.ts
+++ b/src/sources/resolver.ts
@@ -1,7 +1,11 @@
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import { type KustodianErrorType, type ResultType, failure, success } from '../core/index.js';
-import { type TemplateSourceType, is_mutable_source } from '../schema/index.js';
+import {
+  type TemplateSourceType,
+  is_mutable_source,
+  normalize_template_source,
+} from '../schema/index.js';
 import { type CacheManagerType, create_cache_manager } from './cache/index.js';
 import { get_fetcher_for_source } from './fetchers/index.js';
 import type {
@@ -77,15 +81,18 @@ class SourceResolver implements SourceResolverType {
     options?: FetchOptionsType,
   ): Promise<ResultType<ResolvedSourceType, KustodianErrorType>> {
     const force_refresh = options?.force_refresh ?? false;
-    const fetcher_result = get_fetcher_for_source(source);
+    // Normalize once: GitHub sources get rewritten to git, then handled
+    // uniformly by the fetcher selection, cache key, and mutability logic.
+    const normalized = normalize_template_source(source);
+    const fetcher_result = get_fetcher_for_source(normalized);
     if (!fetcher_result.success) {
       return fetcher_result;
     }
     const fetcher = fetcher_result.value;
-    const mutable = is_mutable_source(source);
+    const mutable = is_mutable_source(normalized);
 
     // Cache key is based on the requested source ref (branch/tag/checksum/etc.)
-    const cache_key = this.get_source_version(source);
+    const cache_key = this.get_source_version(normalized);
 
     // Check cache first (unless force refresh)
     if (!force_refresh) {
@@ -104,7 +111,7 @@ class SourceResolver implements SourceResolverType {
     }
 
     // Fetch from remote
-    const fetch_result = await fetcher.fetch(source, options);
+    const fetch_result = await fetcher.fetch(normalized, options);
     if (!fetch_result.success) {
       return fetch_result;
     }

--- a/tests/fixtures/example-git-template-repo/README.md
+++ b/tests/fixtures/example-git-template-repo/README.md
@@ -1,0 +1,5 @@
+# Example Git Template Repository
+
+This fixture is copied into a temporary Git repository by `tests/sources/loader.test.ts`.
+It models the shape of a small template library that a project can consume through
+`spec.template_sources`.

--- a/tests/fixtures/example-git-template-repo/app/configmap.yaml
+++ b/tests/fixtures/example-git-template-repo/app/configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: example-git-web-app-config
+  namespace: example-git-web-app
+data:
+  MESSAGE: "served from an external git template"

--- a/tests/fixtures/example-git-template-repo/app/deployment.yaml
+++ b/tests/fixtures/example-git-template-repo/app/deployment.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-git-web-app
+  namespace: example-git-web-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: example-git-web-app
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: example-git-web-app
+    spec:
+      containers:
+        - name: web
+          image: nginx:1.27-alpine
+          ports:
+            - name: http
+              containerPort: 80
+          envFrom:
+            - configMapRef:
+                name: example-git-web-app-config

--- a/tests/fixtures/example-git-template-repo/app/kustomization.yaml
+++ b/tests/fixtures/example-git-template-repo/app/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - configmap.yaml
+  - deployment.yaml
+  - service.yaml

--- a/tests/fixtures/example-git-template-repo/app/namespace.yaml
+++ b/tests/fixtures/example-git-template-repo/app/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: example-git-web-app

--- a/tests/fixtures/example-git-template-repo/app/service.yaml
+++ b/tests/fixtures/example-git-template-repo/app/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-git-web-app
+  namespace: example-git-web-app
+spec:
+  selector:
+    app.kubernetes.io/name: example-git-web-app
+  ports:
+    - name: http
+      port: 80
+      targetPort: http

--- a/tests/fixtures/example-git-template-repo/template.yaml
+++ b/tests/fixtures/example-git-template-repo/template.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustodian.io/v1
+kind: Template
+metadata:
+  name: example-git-web-app
+spec:
+  kustomizations:
+    - name: app
+      path: ./app

--- a/tests/schema/sources.test.ts
+++ b/tests/schema/sources.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from 'bun:test';
+
+import {
+  is_github_source,
+  is_mutable_source,
+  normalize_template_source,
+  validate_template_source,
+} from '../../src/schema/sources.js';
+
+describe('Template Source Schema', () => {
+  describe('git source', () => {
+    it('accepts a git source with a tag ref', () => {
+      const result = validate_template_source({
+        name: 'apps',
+        git: {
+          url: 'https://example.com/repo.git',
+          ref: { tag: 'v1.0.0' },
+        },
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects when no source variant is specified', () => {
+      const result = validate_template_source({ name: 'apps' });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects when more than one variant is specified', () => {
+      const result = validate_template_source({
+        name: 'apps',
+        git: { url: 'https://example.com/repo.git', ref: { tag: 'v1' } },
+        http: { url: 'https://example.com/archive.tar.gz' },
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('github source - object form', () => {
+    it('accepts a github source with a tag', () => {
+      const result = validate_template_source({
+        name: 'apps',
+        github: {
+          repo: 'octocat/hello-world',
+          ref: { tag: 'v2.3.4' },
+        },
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(is_github_source(result.data)).toBe(true);
+      }
+    });
+
+    it('accepts a github source with a sub-path', () => {
+      const result = validate_template_source({
+        name: 'apps',
+        github: {
+          repo: 'octocat/hello-world',
+          ref: { branch: 'main' },
+          path: 'examples/template',
+        },
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects an invalid repo identifier', () => {
+      const result = validate_template_source({
+        name: 'apps',
+        github: { repo: 'no-slash', ref: { tag: 'v1' } },
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects when no ref kind is specified', () => {
+      const result = validate_template_source({
+        name: 'apps',
+        github: { repo: 'octocat/hello-world', ref: {} },
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('github source - shorthand string form', () => {
+    it('parses a tag-shaped ref', () => {
+      const result = validate_template_source({
+        name: 'apps',
+        github: 'octocat/hello-world@v1.2.3',
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.github).toEqual({
+          repo: 'octocat/hello-world',
+          ref: { tag: 'v1.2.3' },
+        });
+      }
+    });
+
+    it('parses a branch-shaped ref', () => {
+      const result = validate_template_source({
+        name: 'apps',
+        github: 'octocat/hello-world@main',
+      });
+      expect(result.success).toBe(true);
+      if (result.success && result.data.github && typeof result.data.github !== 'string') {
+        expect(result.data.github.ref).toEqual({ branch: 'main' });
+      }
+    });
+
+    it('parses a 40-char commit SHA as a commit ref', () => {
+      const sha = 'a'.repeat(40);
+      const result = validate_template_source({
+        name: 'apps',
+        github: `octocat/hello-world@${sha}`,
+      });
+      expect(result.success).toBe(true);
+      if (result.success && result.data.github && typeof result.data.github !== 'string') {
+        expect(result.data.github.ref).toEqual({ commit: sha });
+      }
+    });
+
+    it('parses a sub-path after a colon', () => {
+      const result = validate_template_source({
+        name: 'apps',
+        github: 'octocat/hello-world@v1.0.0:apps/web',
+      });
+      expect(result.success).toBe(true);
+      if (result.success && result.data.github && typeof result.data.github !== 'string') {
+        expect(result.data.github).toEqual({
+          repo: 'octocat/hello-world',
+          ref: { tag: 'v1.0.0' },
+          path: 'apps/web',
+        });
+      }
+    });
+
+    it('rejects shorthand without an @ ref', () => {
+      const result = validate_template_source({
+        name: 'apps',
+        github: 'octocat/hello-world',
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('normalize_template_source', () => {
+    it('rewrites a github source to the equivalent git source', () => {
+      const parsed = validate_template_source({
+        name: 'apps',
+        github: 'octocat/hello-world@v1.0.0:apps/web',
+        ttl: '1h',
+      });
+      expect(parsed.success).toBe(true);
+      if (!parsed.success) return;
+
+      const normalized = normalize_template_source(parsed.data);
+      expect(normalized.git).toEqual({
+        url: 'https://github.com/octocat/hello-world.git',
+        ref: { tag: 'v1.0.0' },
+        path: 'apps/web',
+      });
+      expect(normalized.github).toBeUndefined();
+      expect(normalized.ttl).toBe('1h');
+    });
+
+    it('passes through non-github sources unchanged', () => {
+      const parsed = validate_template_source({
+        name: 'apps',
+        git: { url: 'https://example.com/repo.git', ref: { tag: 'v1.0.0' } },
+      });
+      expect(parsed.success).toBe(true);
+      if (!parsed.success) return;
+      expect(normalize_template_source(parsed.data)).toBe(parsed.data);
+    });
+  });
+
+  describe('is_mutable_source', () => {
+    it('treats github branches as mutable', () => {
+      const parsed = validate_template_source({
+        name: 'apps',
+        github: 'octocat/hello-world@main',
+      });
+      expect(parsed.success).toBe(true);
+      if (!parsed.success) return;
+      expect(is_mutable_source(parsed.data)).toBe(true);
+    });
+
+    it('treats github tags as immutable', () => {
+      const parsed = validate_template_source({
+        name: 'apps',
+        github: 'octocat/hello-world@v1.0.0',
+      });
+      expect(parsed.success).toBe(true);
+      if (!parsed.success) return;
+      expect(is_mutable_source(parsed.data)).toBe(false);
+    });
+  });
+});

--- a/tests/sources/loader.test.ts
+++ b/tests/sources/loader.test.ts
@@ -1,0 +1,297 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { execFileSync } from 'node:child_process';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { load_project } from '../../src/loader/project.js';
+import { load_templates_from_sources } from '../../src/sources/loader.js';
+
+/**
+ * Initializes a bare-style local git repo with the given file tree and
+ * returns its `file://` URL. The repo has a single commit on `main` and
+ * a tag `v1.0.0` pointing at that commit, which is enough for the
+ * fetcher to clone with `--branch`.
+ */
+async function init_git_template_repo(
+  parent: string,
+  name: string,
+  files: Record<string, string>,
+): Promise<string> {
+  const repo_dir = path.join(parent, name);
+  await fs.mkdir(repo_dir, { recursive: true });
+
+  // Scrub any GIT_* variables that the parent process may have inherited
+  // (e.g. when these tests run inside a `git push` pre-push hook). Leaving
+  // GIT_DIR/GIT_WORK_TREE/etc. set would point our `git init` at the
+  // outer repository instead of the temp directory.
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (value !== undefined && !key.startsWith('GIT_')) {
+      env[key] = value;
+    }
+  }
+  env.GIT_AUTHOR_NAME = 'Test';
+  env.GIT_AUTHOR_EMAIL = 'test@example.com';
+  env.GIT_COMMITTER_NAME = 'Test';
+  env.GIT_COMMITTER_EMAIL = 'test@example.com';
+
+  execFileSync('git', ['init', '-q', '-b', 'main'], { cwd: repo_dir, env });
+
+  for (const [rel, contents] of Object.entries(files)) {
+    const target = path.join(repo_dir, rel);
+    await fs.mkdir(path.dirname(target), { recursive: true });
+    await fs.writeFile(target, contents);
+  }
+
+  execFileSync('git', ['add', '.'], { cwd: repo_dir, env });
+  execFileSync('git', ['commit', '-q', '-m', 'init'], { cwd: repo_dir, env });
+  execFileSync('git', ['tag', 'v1.0.0'], { cwd: repo_dir, env });
+
+  // Allow file:// clones with --depth=1 (modern git refuses by default
+  // for local protocol unless we set this config or use the protocol
+  // explicitly via `file://` URL — we do both).
+  execFileSync('git', ['config', 'uploadpack.allowFilter', 'true'], { cwd: repo_dir, env });
+
+  return `file://${repo_dir}`;
+}
+
+const SINGLE_TEMPLATE = `apiVersion: kustodian.io/v1
+kind: Template
+metadata:
+  name: nginx
+spec:
+  kustomizations:
+    - name: app
+      path: ./app
+`;
+
+const MULTI_TEMPLATE_A = `apiVersion: kustodian.io/v1
+kind: Template
+metadata:
+  name: redis
+spec:
+  kustomizations:
+    - name: app
+      path: ./app
+`;
+
+const MULTI_TEMPLATE_B = `apiVersion: kustodian.io/v1
+kind: Template
+metadata:
+  name: postgres
+spec:
+  kustomizations:
+    - name: app
+      path: ./app
+`;
+
+describe('Sources loader (live local git)', () => {
+  let work_dir: string;
+
+  beforeEach(async () => {
+    work_dir = await fs.mkdtemp(path.join(os.tmpdir(), 'kustodian-sources-test-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(work_dir, { recursive: true, force: true });
+  });
+
+  it('loads a single template from a repo with a root template.yaml', async () => {
+    const url = await init_git_template_repo(work_dir, 'single-repo', {
+      'template.yaml': SINGLE_TEMPLATE,
+      'app/kustomization.yaml': 'resources: []\n',
+    });
+
+    const cache_dir = path.join(work_dir, '.cache');
+    const result = await load_templates_from_sources(
+      [
+        {
+          name: 'single',
+          git: { url, ref: { tag: 'v1.0.0' } },
+        },
+      ],
+      { cache_dir },
+    );
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.value.templates).toHaveLength(1);
+    expect(result.value.templates[0]?.template.metadata.name).toBe('nginx');
+    expect(result.value.templates[0]?.source_name).toBe('single');
+  });
+
+  it('loads multiple templates from a repo with one template per subdirectory', async () => {
+    const url = await init_git_template_repo(work_dir, 'multi-repo', {
+      'redis/template.yaml': MULTI_TEMPLATE_A,
+      'redis/app/kustomization.yaml': 'resources: []\n',
+      'postgres/template.yaml': MULTI_TEMPLATE_B,
+      'postgres/app/kustomization.yaml': 'resources: []\n',
+    });
+
+    const cache_dir = path.join(work_dir, '.cache');
+    const result = await load_templates_from_sources(
+      [
+        {
+          name: 'multi',
+          git: { url, ref: { tag: 'v1.0.0' } },
+        },
+      ],
+      { cache_dir },
+    );
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    const names = result.value.templates.map((t) => t.template.metadata.name).sort();
+    expect(names).toEqual(['postgres', 'redis']);
+  });
+
+  it('honours the path option to scope into a sub-directory', async () => {
+    const url = await init_git_template_repo(work_dir, 'scoped-repo', {
+      'docs/README.md': '# unrelated\n',
+      'pkg/redis/template.yaml': MULTI_TEMPLATE_A,
+      'pkg/redis/app/kustomization.yaml': 'resources: []\n',
+      'pkg/postgres/template.yaml': MULTI_TEMPLATE_B,
+      'pkg/postgres/app/kustomization.yaml': 'resources: []\n',
+    });
+
+    const cache_dir = path.join(work_dir, '.cache');
+    const result = await load_templates_from_sources(
+      [
+        {
+          name: 'scoped',
+          git: { url, ref: { tag: 'v1.0.0' }, path: 'pkg' },
+        },
+      ],
+      { cache_dir },
+    );
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    const names = result.value.templates.map((t) => t.template.metadata.name).sort();
+    expect(names).toEqual(['postgres', 'redis']);
+  });
+
+  it('integrates external templates into load_project alongside local ones', async () => {
+    const url = await init_git_template_repo(work_dir, 'integ-repo', {
+      'template.yaml': SINGLE_TEMPLATE,
+      'app/kustomization.yaml': 'resources: []\n',
+    });
+
+    const project_root = path.join(work_dir, 'project');
+    await fs.mkdir(project_root, { recursive: true });
+
+    // Local template
+    const local_template_dir = path.join(project_root, 'templates', 'local-app');
+    await fs.mkdir(local_template_dir, { recursive: true });
+    await fs.writeFile(
+      path.join(local_template_dir, 'template.yaml'),
+      `apiVersion: kustodian.io/v1
+kind: Template
+metadata:
+  name: local-app
+spec:
+  kustomizations:
+    - name: app
+      path: ./app
+`,
+    );
+
+    // kustodian.yaml referencing the local repo as a source
+    await fs.writeFile(
+      path.join(project_root, 'kustodian.yaml'),
+      `apiVersion: kustodian.io/v1
+kind: Project
+metadata:
+  name: integ
+spec:
+  template_sources:
+    - name: integ-source
+      git:
+        url: ${url}
+        ref:
+          tag: v1.0.0
+`,
+    );
+
+    const result = await load_project(project_root, {
+      fetch_sources: true,
+      cache_dir: path.join(work_dir, '.cache'),
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    const names = result.value.templates.map((t) => t.template.metadata.name).sort();
+    expect(names).toEqual(['local-app', 'nginx']);
+
+    const sourced = result.value.templates.find((t) => t.source_name === 'integ-source');
+    expect(sourced?.template.metadata.name).toBe('nginx');
+    expect(result.value.resolved_sources).toHaveLength(1);
+    expect(result.value.resolved_sources?.[0]?.name).toBe('integ-source');
+  });
+
+  it('flags conflicts when a sourced template name shadows a local template', async () => {
+    const url = await init_git_template_repo(work_dir, 'clash-repo', {
+      'template.yaml': SINGLE_TEMPLATE,
+      'app/kustomization.yaml': 'resources: []\n',
+    });
+
+    const project_root = path.join(work_dir, 'project');
+    await fs.mkdir(path.join(project_root, 'templates', 'nginx'), { recursive: true });
+    await fs.writeFile(
+      path.join(project_root, 'templates', 'nginx', 'template.yaml'),
+      SINGLE_TEMPLATE,
+    );
+    await fs.writeFile(
+      path.join(project_root, 'kustodian.yaml'),
+      `apiVersion: kustodian.io/v1
+kind: Project
+metadata:
+  name: clash
+spec:
+  template_sources:
+    - name: clash-source
+      git:
+        url: ${url}
+        ref:
+          tag: v1.0.0
+`,
+    );
+
+    const result = await load_project(project_root, {
+      fetch_sources: true,
+      cache_dir: path.join(work_dir, '.cache'),
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.message).toContain('nginx');
+    }
+  });
+
+  it('skips source fetching when fetch_sources is false', async () => {
+    const project_root = path.join(work_dir, 'project');
+    await fs.mkdir(project_root, { recursive: true });
+    await fs.writeFile(
+      path.join(project_root, 'kustodian.yaml'),
+      `apiVersion: kustodian.io/v1
+kind: Project
+metadata:
+  name: noop
+spec:
+  template_sources:
+    - name: should-not-fetch
+      git:
+        url: file:///nonexistent-path-that-would-fail
+        ref:
+          tag: v1.0.0
+`,
+    );
+
+    const result = await load_project(project_root);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.value.templates).toEqual([]);
+    expect(result.value.resolved_sources).toBeUndefined();
+  });
+});

--- a/tests/sources/loader.test.ts
+++ b/tests/sources/loader.test.ts
@@ -7,6 +7,35 @@ import * as path from 'node:path';
 import { load_project } from '../../src/loader/project.js';
 import { load_templates_from_sources } from '../../src/sources/loader.js';
 
+const EXAMPLE_GIT_TEMPLATE_REPO = path.join(
+  import.meta.dir,
+  '..',
+  'fixtures',
+  'example-git-template-repo',
+);
+
+function git_test_env(): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (value !== undefined && !key.startsWith('GIT_')) {
+      env[key] = value;
+    }
+  }
+  env.GIT_AUTHOR_NAME = 'Test';
+  env.GIT_AUTHOR_EMAIL = 'test@example.com';
+  env.GIT_COMMITTER_NAME = 'Test';
+  env.GIT_COMMITTER_EMAIL = 'test@example.com';
+  return env;
+}
+
+function commit_git_template_repo(repo_dir: string, env: Record<string, string>): void {
+  execFileSync('git', ['init', '-q', '-b', 'main'], { cwd: repo_dir, env });
+  execFileSync('git', ['add', '.'], { cwd: repo_dir, env });
+  execFileSync('git', ['commit', '-q', '-m', 'init'], { cwd: repo_dir, env });
+  execFileSync('git', ['tag', 'v1.0.0'], { cwd: repo_dir, env });
+  execFileSync('git', ['config', 'uploadpack.allowFilter', 'true'], { cwd: repo_dir, env });
+}
+
 /**
  * Initializes a bare-style local git repo with the given file tree and
  * returns its `file://` URL. The repo has a single commit on `main` and
@@ -21,38 +50,26 @@ async function init_git_template_repo(
   const repo_dir = path.join(parent, name);
   await fs.mkdir(repo_dir, { recursive: true });
 
-  // Scrub any GIT_* variables that the parent process may have inherited
-  // (e.g. when these tests run inside a `git push` pre-push hook). Leaving
-  // GIT_DIR/GIT_WORK_TREE/etc. set would point our `git init` at the
-  // outer repository instead of the temp directory.
-  const env: Record<string, string> = {};
-  for (const [key, value] of Object.entries(process.env)) {
-    if (value !== undefined && !key.startsWith('GIT_')) {
-      env[key] = value;
-    }
-  }
-  env.GIT_AUTHOR_NAME = 'Test';
-  env.GIT_AUTHOR_EMAIL = 'test@example.com';
-  env.GIT_COMMITTER_NAME = 'Test';
-  env.GIT_COMMITTER_EMAIL = 'test@example.com';
-
-  execFileSync('git', ['init', '-q', '-b', 'main'], { cwd: repo_dir, env });
-
   for (const [rel, contents] of Object.entries(files)) {
     const target = path.join(repo_dir, rel);
     await fs.mkdir(path.dirname(target), { recursive: true });
     await fs.writeFile(target, contents);
   }
 
-  execFileSync('git', ['add', '.'], { cwd: repo_dir, env });
-  execFileSync('git', ['commit', '-q', '-m', 'init'], { cwd: repo_dir, env });
-  execFileSync('git', ['tag', 'v1.0.0'], { cwd: repo_dir, env });
+  commit_git_template_repo(repo_dir, git_test_env());
 
-  // Allow file:// clones with --depth=1 (modern git refuses by default
-  // for local protocol unless we set this config or use the protocol
-  // explicitly via `file://` URL — we do both).
-  execFileSync('git', ['config', 'uploadpack.allowFilter', 'true'], { cwd: repo_dir, env });
+  return `file://${repo_dir}`;
+}
 
+async function init_git_template_repo_from_fixture(
+  parent: string,
+  name: string,
+  fixture_dir: string,
+): Promise<string> {
+  const repo_dir = path.join(parent, name);
+  await fs.mkdir(repo_dir, { recursive: true });
+  await fs.cp(fixture_dir, repo_dir, { recursive: true });
+  commit_git_template_repo(repo_dir, git_test_env());
   return `file://${repo_dir}`;
 }
 
@@ -229,6 +246,47 @@ spec:
     expect(sourced?.template.metadata.name).toBe('nginx');
     expect(result.value.resolved_sources).toHaveLength(1);
     expect(result.value.resolved_sources?.[0]?.name).toBe('integ-source');
+  });
+
+  it('integrates a committed example git template fixture into load_project', async () => {
+    const url = await init_git_template_repo_from_fixture(
+      work_dir,
+      'example-git-template-repo',
+      EXAMPLE_GIT_TEMPLATE_REPO,
+    );
+
+    const project_root = path.join(work_dir, 'project');
+    await fs.mkdir(project_root, { recursive: true });
+    await fs.writeFile(
+      path.join(project_root, 'kustodian.yaml'),
+      `apiVersion: kustodian.io/v1
+kind: Project
+metadata:
+  name: fixture-source
+spec:
+  template_sources:
+    - name: example-git-template
+      git:
+        url: ${url}
+        ref:
+          tag: v1.0.0
+`,
+    );
+
+    const result = await load_project(project_root, {
+      fetch_sources: true,
+      cache_dir: path.join(work_dir, '.cache'),
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    expect(result.value.templates).toHaveLength(1);
+    const [template] = result.value.templates;
+    expect(template?.source_name).toBe('example-git-template');
+    expect(template?.template.metadata.name).toBe('example-git-web-app');
+    expect(template?.template.spec.kustomizations.map((item) => item.path)).toEqual(['./app']);
+    expect(result.value.resolved_sources?.[0]?.name).toBe('example-git-template');
   });
 
   it('flags conflicts when a sourced template name shadows a local template', async () => {


### PR DESCRIPTION
## Summary

Adds first-class support for consuming versioned templates from GitHub (and any Git/HTTP/OCI source) repos that host either a single template or many templates at once.

- New `github` source variant on `template_sources`, with both an object form and a shorthand string `owner/repo@<branch|tag|commit>[:path]`. The shorthand parser infers the ref kind: 40-char hex → `commit`, semver-shaped → `tag`, anything else → `branch`. Internally normalized to a Git source pointing at `https://github.com/<owner>/<repo>.git` so the existing Git fetcher, cache, and TTL logic apply unchanged.
- `template_sources` is now a validated field on `project_spec_schema`, replacing the ad-hoc YAML parsing in the `sources` CLI command.
- `load_project` accepts `{ fetch_sources, cache_dir, force_refresh }`. When enabled, sources are fetched, merged into `templates` with a `source_name` tag, and a `resolved_sources` summary is attached. Name collisions between local and sourced templates fail loudly. `apply`, `diff`, `validate`, and `update` opt in by default.
- Source loader now uses the recursive `find_template_directories` walk, so a fetched repo can host either a single root `template.yaml` or many under subdirectories — both layouts work without configuration.
- The Git fetcher scrubs `GIT_*` env vars before invoking subprocess `git`, so it's safe to run kustodian from inside another git operation (e.g. a pre-push hook) without inheriting `GIT_DIR`/`GIT_WORK_TREE`/etc. from the outer process.

## Why

Lets templates live outside the consuming project's repo so a team can publish a versioned template library once and pin every consumer to a tag. The GitHub shorthand keeps `kustodian.yaml` readable for the common case while preserving access to the full Git/HTTP/OCI matrix for non-GitHub hosts.

## Reviewer notes

- New tests cover schema parsing (16 cases incl. shorthand parsing, ref-kind inference, normalization, mutability) and live-git integration via `git init` against temp directories (single-template, multi-template, sub-path scoping, full `load_project` integration, name-collision detection, and `fetch_sources: false` opt-out).
- Docs updated: a new "External template sources" section in [reference/config/project](docs/src/content/docs/reference/config/project.mdx) and a cross-reference from [concepts/templates](docs/src/content/docs/concepts/templates.mdx).
- The `LoadedTemplateType` interface now carries an optional `source_name`. Local templates leave it undefined; sourced templates carry the source's name.
- No breaking changes to `kustodian.yaml`: projects without `spec.template_sources` behave exactly as before.

## Test plan

- [ ] `bun test` passes (verified locally, 951 tests, 0 fail).
- [ ] `bun run lint` and `bun run typecheck` clean (verified locally).
- [ ] Configure a `template_sources` entry pointing at a real GitHub repo with `github: owner/repo@v1.0.0` and confirm `kustodian sources fetch` populates `.kustodian/templates-cache`.
- [ ] Run `kustodian validate` and confirm cached + local templates are merged in the output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)